### PR TITLE
Immutable Mix Temperature Gradient

### DIFF
--- a/byond-extools/src/monstermos/GasMixture.h
+++ b/byond-extools/src/monstermos/GasMixture.h
@@ -38,6 +38,8 @@ class GasMixture
 		int compare(GasMixture &sample) const;
 		void clear();
 		void multiply(float multiplier);
+        bool create_temperature_gradient(float a, float b, float c);
+        void tick_temperature_gradient(float step);
 
         inline float get_temperature() const { return temperature; }
         inline void set_temperature(float new_temp) { if(!immutable) temperature = new_temp; }
@@ -57,6 +59,9 @@ class GasMixture
         float last_share = 0;
 		float min_heat_capacity = 0;
         bool immutable = false;
+        float gradient_coeff_a;
+        float gradient_coeff_b;
+        float gradient_coeff_c;
 	// you might thing, "damn, all the gases, wont that use up more memory"?
 	// well no. Let's look at the average gas mixture in BYOND land containing both oxygen and nitrogen:
 	// gases (28+8 bytes)

--- a/byond-extools/src/monstermos/monstermos.cpp
+++ b/byond-extools/src/monstermos/monstermos.cpp
@@ -269,9 +269,9 @@ trvh gasmixture_multiply(unsigned int args_len, Value* args, Value src)
 trvh gasmixture_create_temperature_gradient(unsigned int args_len, Value* args, Value src)
 {
 	if(args_len < 3) {
-		return Value::Null();
+		return Value::False();
 	} else if(args[0].type != NUMBER || args[1].type != NUMBER || args[2].type != NUMBER) {
-		return Value::Null();
+		return Value::False();
 	} else if (get_gas_mixture(src)->create_temperature_gradient(args[0].valuef, args[1].valuef, args[2].valuef)) {
 		return Value::True();
 	} else {

--- a/byond-extools/src/monstermos/monstermos.cpp
+++ b/byond-extools/src/monstermos/monstermos.cpp
@@ -266,6 +266,29 @@ trvh gasmixture_multiply(unsigned int args_len, Value* args, Value src)
 	return Value::Null();
 }
 
+trvh gasmixture_create_temperature_gradient(unsigned int args_len, Value* args, Value src)
+{
+	if(args_len < 3) {
+		return Value::Null();
+	} else if(args[0].type != NUMBER || args[1].type != NUMBER || args[2].type != NUMBER) {
+		return Value::Null();
+	} else if (get_gas_mixture(src)->create_temperature_gradient(args[0].valuef, args[1].valuef, args[2].valuef)) {
+		return Value::True();
+	} else {
+		return Value::False();
+	}
+}
+
+trvh gasmixture_tick_temperature_gradient(unsigned int args_len, Value* args, Value src)
+{
+	if(args_len < 1) { return Value::Null(); }
+	else if(args[0].type != NUMBER) { return Value::Null(); }
+	else {
+		get_gas_mixture(src)->tick_temperature_gradient(args[0].valuef);
+		return Value::Null();
+	}
+}
+
 trvh turf_update_adjacent(unsigned int args_len, Value* args, Value src)
 {
 	if (src.type != TURF) { return Value::Null(); }
@@ -530,6 +553,8 @@ const char* enable_monstermos()
 	Core::get_proc("/datum/gas_mixture/proc/mark_immutable").hook(gasmixture_mark_immutable);
 	Core::get_proc("/datum/gas_mixture/proc/clear").hook(gasmixture_clear);
 	Core::get_proc("/datum/gas_mixture/proc/multiply").hook(gasmixture_multiply);
+	Core::get_proc("/datum/gas_mixture/proc/create_temperature_gradient").hook(gasmixture_create_temperature_gradient);
+	Core::get_proc("/datum/gas_mixture/proc/tick_temperature_gradient").hook(gasmixture_tick_temperature_gradient);
 	Core::get_proc("/datum/gas_mixture/proc/get_last_share").hook(gasmixture_get_last_share);
 	Core::get_proc("/turf/proc/__update_extools_adjacent_turfs").hook(turf_update_adjacent);
 	Core::get_proc("/turf/proc/update_air_ref").hook(turf_update_air_ref);


### PR DESCRIPTION
Creates hooks to be able to add temperature gradients to immutable gas-mixes, primarily for use in planetary day/night cycles.