### PR TITLE
fixes a bug where immutable mixes would always explosively decompress…

### DIFF
--- a/byond-extools/src/monstermos/turf_grid.cpp
+++ b/byond-extools/src/monstermos/turf_grid.cpp
@@ -352,7 +352,7 @@ void Tile::equalize_pressure_in_zone(int cyclenum) {
 			}
 			adj->monstermos_info->last_queue_cycle = queue_cycle;
 			turfs.push_back(adj);
-			if (adj->air->is_immutable()) {
+			if (adj->air->is_immutable() && adj->air->total_moles() == 0) {
 				// Uh oh! looks like someone opened an airlock to space! TIME TO SUCK ALL THE AIR OUT!!!
 				// NOT ONE OF YOU IS GONNA SURVIVE THIS
 				// (I just made explosions less laggy, you're welcome)


### PR DESCRIPTION
…, even if they weren't space tiles